### PR TITLE
change to use autoVersioning flag

### DIFF
--- a/src/main/java/io/weidongxu/util/releaseautomation/Configure.java
+++ b/src/main/java/io/weidongxu/util/releaseautomation/Configure.java
@@ -6,7 +6,7 @@ public class Configure {
     private String swagger;
 
     // preview release
-    private boolean preview;
+    private boolean autoVersioning;
 
     // used only if preview=false
     // if preview=true, uses current next release version in https://github.com/Azure/azure-sdk-for-java/blob/main/eng/versioning/version_client.txt
@@ -31,12 +31,12 @@ public class Configure {
         this.swagger = swagger;
     }
 
-    public boolean isPreview() {
-        return preview;
+    public boolean isAutoVersioning() {
+        return autoVersioning;
     }
 
-    public void setPreview(boolean preview) {
-        this.preview = preview;
+    public void setAutoVersioning(boolean autoVersioning) {
+        this.autoVersioning = autoVersioning;
     }
 
     public String getTag() {

--- a/src/main/java/io/weidongxu/util/releaseautomation/Configure.java
+++ b/src/main/java/io/weidongxu/util/releaseautomation/Configure.java
@@ -6,7 +6,7 @@ public class Configure {
     private String swagger;
 
     // preview release
-    private boolean autoVersioning;
+    private boolean autoVersioning = true;
 
     // used only if preview=false
     // if preview=true, uses current next release version in https://github.com/Azure/azure-sdk-for-java/blob/main/eng/versioning/version_client.txt

--- a/src/main/java/io/weidongxu/util/releaseautomation/LiteRelease.java
+++ b/src/main/java/io/weidongxu/util/releaseautomation/LiteRelease.java
@@ -147,11 +147,11 @@ public class LiteRelease {
         }
         OUT.println("tag: " + tag);
 
-        if (configure.isPreview() && !tag.contains("preview") && !tag.contains("composite")) {
+        if (configure.isAutoVersioning() && !tag.contains("preview")) {
             // if stable is released, and current tag is also stable
             VersionConfigure.parseVersion(HTTP_PIPELINE, sdk).ifPresent(sdkVersion -> {
                 if (sdkVersion.isStableReleased()) {
-                    configure.setPreview(false);
+                    configure.setAutoVersioning(false);
                     configure.setVersion(sdkVersion.getCurrentVersionAsStable());
 
                     OUT.println("release for stable: " + configure.getVersion());
@@ -174,7 +174,7 @@ public class LiteRelease {
         variables.put("README", new Variable().withValue(swagger));
         variables.put("TAG", new Variable().withValue(tag));
         variables.put("DRAFT_PULL_REQUEST", new Variable().withValue("false"));
-        if (!configure.isPreview()) {
+        if (!configure.isAutoVersioning()) {
             variables.put("VERSION", new Variable().withValue(configure.getVersion()));
         }
         if (!CoreUtils.isNullOrEmpty(configure.getService())) {

--- a/src/main/java/io/weidongxu/util/releaseautomation/ReleaseState.java
+++ b/src/main/java/io/weidongxu/util/releaseautomation/ReleaseState.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-class ReleaseState {
+public class ReleaseState {
     private String name;
     private String identifier;
     private TimelineRecordState state;

--- a/src/main/java/io/weidongxu/util/releaseautomation/Utils.java
+++ b/src/main/java/io/weidongxu/util/releaseautomation/Utils.java
@@ -1,6 +1,7 @@
 package io.weidongxu.util.releaseautomation;
 
 import com.azure.core.http.HttpMethod;
+import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpRequest;
 import com.azure.core.http.HttpResponse;
 import com.azure.dev.DevManager;
@@ -13,6 +14,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 import java.util.Locale;
 import java.util.Scanner;
@@ -21,7 +24,7 @@ import java.util.stream.Collectors;
 
 public class Utils {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(Utils.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Utils.class);
 
     public static ReleaseState getReleaseState(TimelineRecord record, Timeline timeline) {
         ReleaseState state = new ReleaseState();
@@ -98,5 +101,15 @@ public class Utils {
         } catch (IOException e) {
             LOGGER.error("Browser could not be opened - please open {} in a browser on this device.", url);
         }
+    }
+
+    private static final String SPEC_REPO_PATH_PREFIX = "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/";
+    private static final String SPEC_REPO_SPEC_PATH_PREFIX = "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/";
+
+    public static ReadmeConfigure getReadmeConfigure(HttpPipeline httpPipeline, String swagger) throws MalformedURLException {
+        String readmeUrl = swagger.contains("/")
+                ? SPEC_REPO_PATH_PREFIX + swagger
+                : SPEC_REPO_SPEC_PATH_PREFIX + swagger + "/resource-manager/readme.md";
+        return ReadmeConfigure.parseReadme(httpPipeline, new URL(readmeUrl));
     }
 }

--- a/src/main/resources/configure.yml
+++ b/src/main/resources/configure.yml
@@ -1,4 +1,4 @@
 swagger: mediaservices
-preview: true
+autoVersioning: true
 version: 1.0.0
 tests: true


### PR DESCRIPTION
Previous `preview` flag no longer conveys the intention.

Also add one additional check for stable release, that input file in tag not be in preview folder.

`autoVersioning` be 2 conditions
1. if released stable, and current tag can be stable, it would calculate and set the next stable `version` to pipeline (it won't take breaking changes or not into the calculation)
2. if `version` not set to pipeline, pipeline will use the next version in eng/versioning/version_client.txt (a preview version)