### PR TITLE
introduce AzureCLI for authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,11 @@
             <artifactId>azure-core-http-netty</artifactId>
             <version>1.15.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-identity</artifactId>
+            <version>1.13.2</version> <!-- {x-version-update;com.azure:azure-identity;dependency} -->
+        </dependency>
 
         <dependency>
             <groupId>org.kohsuke</groupId>


### PR DESCRIPTION
Use Azure DevOps CLI if no PAT found.

doc: https://learn.microsoft.com/en-us/azure/devops/cli/?view=azure-devops

step:
1. `az extension add --name azure-devops`
2. `az login`
3. release without PAT

After step 1, future release steps should be the same as running resource-manager tests.

tested with following code:
```java
manager.runs().list(ORGANIZATION, PROJECT_INTERNAL, LITE_CODEGEN_PIPELINE_ID).forEach(run -> {
    System.out.println(run.id());
});
```

Not sure if we need step 1 and 2, I tested with them, though haven't tested without them.