### PR TITLE
remove trigger of individual "- ci" pipeline

### DIFF
--- a/src/main/java/io/weidongxu/util/releaseautomation/LiteRelease.java
+++ b/src/main/java/io/weidongxu/util/releaseautomation/LiteRelease.java
@@ -440,17 +440,7 @@ public class LiteRelease {
         Thread.sleep(POLL_SHORT_INTERVAL_MINUTE * MILLISECOND_PER_MINUTE);
 
         Pipeline pipeline = findSdkPipeline(manager, sdk, true);
-
-        boolean ciPipelineReady = pipeline != null;
-
-//        if (ciPipelineReady) {
-//            Map<String, Object> buildDefinition = Utils.getDefinition(manager, ORGANIZATION, PROJECT_PUBLIC, pipeline.id());
-//            if (!Utils.isDefinitionEnabled(buildDefinition)) {
-//                ciPipelineEnabled = false;
-//                OUT.println("enable pipeline");
-//                Utils.enableDefinition(manager, ORGANIZATION, PROJECT_PUBLIC, pipeline.id(), buildDefinition);
-//            }
-//        }
+        final boolean ciPipelineReady = pipeline != null;
 
         if (!ciPipelineReady) {
             LOGGER.info("prepare pipeline");

--- a/src/main/java/io/weidongxu/util/releaseautomation/LiteRelease.java
+++ b/src/main/java/io/weidongxu/util/releaseautomation/LiteRelease.java
@@ -439,10 +439,10 @@ public class LiteRelease {
         OUT.println("wait 1 minutes");
         Thread.sleep(POLL_SHORT_INTERVAL_MINUTE * MILLISECOND_PER_MINUTE);
 
-        Pipeline pipeline = findSdkPipeline(manager, sdk, true);
-        final boolean ciPipelineReady = pipeline != null;
+        Pipeline pipeline = findSdkPipeline(manager, sdk, false);
+        final boolean releasePipelineReady = pipeline != null;
 
-        if (!ciPipelineReady) {
+        if (!releasePipelineReady) {
             LOGGER.info("prepare pipeline");
 
             // comment to create sdk CI

--- a/src/main/java/io/weidongxu/util/releaseautomation/LiteRelease.java
+++ b/src/main/java/io/weidongxu/util/releaseautomation/LiteRelease.java
@@ -74,6 +74,7 @@ public class LiteRelease {
 
     private static final String CI_CHECK_ENFORCER_NAME = "https://aka.ms/azsdk/checkenforcer";
     private static final String CI_PREPARE_PIPELINES_NAME = "prepare-pipelines";
+    private static final String CI_PULL_REQUEST_NAME = "java - pullrequest";
 
     private static final String API_SPECS_YAML_PATH = "https://raw.githubusercontent.com/Azure/azure-sdk-for-java/main/eng/automation/api-specs.yaml";
 
@@ -282,7 +283,7 @@ public class LiteRelease {
 
             if (PROMPT_CONFIRMATION) {
                 Utils.promptMessageAndWait(IN, OUT,
-                        "'Yes' to approve and merge GitHub pull request: https://github.com/Azure/azure-sdk-for-java/pull/" + prNumber);
+                        "'Yes' to approve GitHub pull request: https://github.com/Azure/azure-sdk-for-java/pull/" + prNumber);
             }
 
             // make PR ready
@@ -291,6 +292,11 @@ public class LiteRelease {
 
             // approve PR
             GHPullRequestReview review = pr.createReview().event(GHPullRequestReviewEvent.APPROVE).create();
+
+            if (PROMPT_CONFIRMATION) {
+                Utils.promptMessageAndWait(IN, OUT,
+                        "'Yes' to merge GitHub pull request: https://github.com/Azure/azure-sdk-for-java/pull/" + prNumber);
+            }
 
             // merge PR
             pr.refresh();
@@ -434,19 +440,17 @@ public class LiteRelease {
         Thread.sleep(POLL_SHORT_INTERVAL_MINUTE * MILLISECOND_PER_MINUTE);
 
         Pipeline pipeline = findSdkPipeline(manager, sdk, true);
-        String javaSdkCheckName = pipeline != null ? pipeline.name() : ("java - " + sdk + " - ci");
 
         boolean ciPipelineReady = pipeline != null;
-        boolean ciPipelineEnabled = true;
 
-        if (ciPipelineReady) {
-            Map<String, Object> buildDefinition = Utils.getDefinition(manager, ORGANIZATION, PROJECT_PUBLIC, pipeline.id());
-            if (!Utils.isDefinitionEnabled(buildDefinition)) {
-                ciPipelineEnabled = false;
-                OUT.println("enable pipeline");
-                Utils.enableDefinition(manager, ORGANIZATION, PROJECT_PUBLIC, pipeline.id(), buildDefinition);
-            }
-        }
+//        if (ciPipelineReady) {
+//            Map<String, Object> buildDefinition = Utils.getDefinition(manager, ORGANIZATION, PROJECT_PUBLIC, pipeline.id());
+//            if (!Utils.isDefinitionEnabled(buildDefinition)) {
+//                ciPipelineEnabled = false;
+//                OUT.println("enable pipeline");
+//                Utils.enableDefinition(manager, ORGANIZATION, PROJECT_PUBLIC, pipeline.id(), buildDefinition);
+//            }
+//        }
 
         if (!ciPipelineReady) {
             LOGGER.info("prepare pipeline");
@@ -457,18 +461,7 @@ public class LiteRelease {
             // wait for prepare pipelines
             pr.refresh();
             waitForCheckSuccess(pr, prNumber, CI_PREPARE_PIPELINES_NAME, pr.getHead().getSha());
-
-            // comment to run the newly created sdk CI
-            pr.comment("/azp run " + javaSdkCheckName);
         } else {
-            // comment to run the previously disabled sdk CI
-            if (!ciPipelineEnabled) {
-                pr.comment("/azp run " + javaSdkCheckName);
-                // wait a bit before potentially another "/azp run" comment
-                OUT.println("wait 1 minutes");
-                Thread.sleep(POLL_SHORT_INTERVAL_MINUTE * MILLISECOND_PER_MINUTE);
-            }
-
             // trigger live tests, if available
             String testPipelineName = "java - " + sdk + " - mgmt - tests";
             boolean testPipelineAvailable = manager.pipelines().list(ORGANIZATION, PROJECT_INTERNAL).stream()
@@ -480,7 +473,7 @@ public class LiteRelease {
         }
 
         // wait for sdk CI
-        waitForCheckSuccess(pr, prNumber, javaSdkCheckName);
+        waitForCheckSuccess(pr, prNumber, CI_PULL_REQUEST_NAME);
 
         // wait for check enforcer
         waitForCommitSuccess(pr, prNumber);
@@ -520,8 +513,6 @@ public class LiteRelease {
 
     private static void waitForCheckSuccess(GHPullRequest pr,
                                             int prNumber, String checkName, String fixedCommitSHA) throws InterruptedException, IOException {
-        final String pullRequestCheckName = "java - pullrequest";
-
         String commitSHA = fixedCommitSHA;
         if (commitSHA == null) {
             // refresh head commit
@@ -530,8 +521,7 @@ public class LiteRelease {
         }
         CheckRunListResult checkRunResult = Utils.getCheckRuns(HTTP_PIPELINE, GITHUB_TOKEN, commitSHA);
         CheckRun check = getCheck(checkRunResult.getCheckRuns(), checkName);
-        CheckRun pullRequestCheck = getCheck(checkRunResult.getCheckRuns(), pullRequestCheckName);
-        while (check == null || !"success".equals(check.getConclusion()) || pullRequestCheck == null || !"success".equals(pullRequestCheck.getConclusion())) {
+        while (check == null || !"success".equals(check.getConclusion())) {
             if (check == null) {
                 OUT.println("pr number: " + prNumber + ", wait for " + checkName);
             } else {
@@ -548,7 +538,6 @@ public class LiteRelease {
             }
             checkRunResult = Utils.getCheckRuns(HTTP_PIPELINE, GITHUB_TOKEN, commitSHA);
             check = getCheck(checkRunResult.getCheckRuns(), checkName);
-            pullRequestCheck = getCheck(checkRunResult.getCheckRuns(), pullRequestCheckName);
         }
     }
 


### PR DESCRIPTION
CI would use `java - pullrequest` instead

The check on `java - <service>` still exists, and is for deciding whether to call `prepare-pipeline`.

---

Also:
- disabled the "enable CI" step
- add another "yes" input from dev, as dev may need to resolve some comments from Copilot


![image](https://github.com/user-attachments/assets/1def2c02-2c95-42ff-a7ee-2a00ee3c014b)